### PR TITLE
UI: article readability polish

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -88,7 +88,7 @@ header h1 {
 header h2 {
   font-size: 18px;
   font-weight: 300;
-  color: #666;
+  color: #9a9a9a;
 }
 
 /* Main Content
@@ -107,25 +107,22 @@ h1, h2, h3, h4, h5, h6 {
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   color: $header;
   letter-spacing: -0.03em;
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1),
-               0 0 5px rgba(181, 232, 83, 0.1),
-               0 0 10px rgba(181, 232, 83, 0.1);
 }
 
 #main_content h1 {
-  font-size: 30px;
+  font-size: 34px;
 }
 
 #main_content h2 {
-  font-size: 24px;
+  font-size: 26px;
 }
 
 #main_content h3 {
-  font-size: 18px;
+  font-size: 20px;
 }
 
 #main_content h4 {
-  font-size: 14px;
+  font-size: 16px;
 }
 
 #main_content h5 {
@@ -137,7 +134,7 @@ h1, h2, h3, h4, h5, h6 {
 #main_content h6 {
   font-size: 12px;
   text-transform: uppercase;
-  color: #999;
+  color: #9a9a9a;
   margin: 0 0 5px 0;
 }
 
@@ -249,16 +246,16 @@ a:hover {
   color: #b5e8ff;
 }
 
-a:active, a:focus {
-  outline: 0;
-  border: none;
-  -moz-outline-style: none
+a:focus-visible {
+  outline: 2px solid $conifer;
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* Post date styling */
 time, .post-date {
   display: block;
-  color: $grey;
+  color: #9a9a9a;
   font-size: 14px;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   margin: -10px 0 20px 0;
@@ -313,4 +310,21 @@ time, .post-date {
 
 #wrapper {
   min-height: calc(100vh - 100px);
+}
+
+/* Readability: cap the article column to ~70-80 chars per line on wide screens.
+   The home/listing stays at container width (it is not wrapped in <article>). */
+article {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+/* Respect users who prefer less motion. */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
Small, surgical CSS changes to make long technical articles read as a reference, keeping the terminal/hacker identity.

- Reading width: cap the article column to 720px (home/listing stays full width).
- Type scale: tighter hierarchy (h1 34 / h2 26 / h3 20 / h4 16).
- Glow: keep the neon glow only on the main header title; remove it from content headings for cleaner long-form reading.
- Contrast: bump low-contrast greys (#666/#999/#888) to #9a9a9a for WCAG-friendlier secondary text (subtitle, h6, post date).
- Accessibility: replace the removed focus outline with a visible :focus-visible ring; respect prefers-reduced-motion.

All edits are in _sass/base.scss. The CSS compiles via GitHub Pages' native Jekyll build (no local Sass toolchain here to pre-verify); braces are balanced and only standard CSS properties/existing variables are used.