### PR TITLE
CI: Jekyll build gate + security.txt

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,21 @@
+name: Build check
+
+# Builds the Jekyll site on every PR to master so template/Liquid errors are
+# caught before they can reach the live (Pages) deploy.
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  jekyll-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://www.linkedin.com/in/rozapelini/
+Contact: https://github.com/renansj
+Expires: 2027-06-02T00:00:00.000Z
+Preferred-Languages: pt, en
+Canonical: https://renansj.dev/.well-known/security.txt

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,8 @@ defaults:
       layout: "post"
 
 future: true
+include:
+  - ".well-known"
 plugins:
   - jekyll-seo-tag
   - jekyll-paginate


### PR DESCRIPTION
- Add a PR build gate (actions/jekyll-build-pages) so template/Liquid errors are caught before the live deploy (like the BibTeX escaping issue that briefly broke master).
- Add RFC 9116 /.well-known/security.txt with LinkedIn + GitHub as contacts; include the dot-directory via _config.yml.