### PR TITLE
TOC sticky sidebar + auto numbering + a11y fixes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
   <meta charset="UTF-8" />
   <meta
     name="viewport"
-    content="width=device-width, initial-scale=1.0, maximum-scale=1"
+    content="width=device-width, initial-scale=1.0"
   />
   <meta
     http-equiv="Content-Security-Policy"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
 {% include head.html %}
 
 <body>
@@ -8,9 +8,9 @@
     <a id="top"></a>
     {% include header.html %}
     <div class="container">
-      <section id="main_content">
+      <main id="main_content">
         {{ content }}
-      </section>
+      </main>
     </div>
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,14 +14,17 @@ layout: default
   </div>
   {% endif %}
 
-  <!-- Table of contents, filled from the post headings by /assets/anchors.js -->
-  <nav class="toc" aria-label="Table of contents" hidden>
-    <p class="toc-title">Contents</p>
-    <ul class="toc-list"></ul>
-  </nav>
+  <div class="post-grid">
+    <div class="post-body">
+      {{ content }}
+    </div>
 
-  <div class="post-body">
-    {{ content }}
+    <!-- Table of contents, filled from the post headings by /assets/anchors.js.
+         Sticky in the side column on wide screens; on top on narrow screens. -->
+    <nav class="toc" aria-label="Table of contents" hidden>
+      <p class="toc-title">Contents</p>
+      <ul class="toc-list"></ul>
+    </nav>
   </div>
 
   <!-- How to cite: built from the post metadata. -->

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -456,6 +456,21 @@ html { scroll-behavior: smooth; }
 .toc-h3 { padding-left: 18px; font-size: 14px; }
 .toc-list a { text-shadow: none; }
 
+/* Automatic section numbering (1, 1.1, ...) on article headings, applied
+   automatically so posts do not need manual numbers in their titles. */
+.post-body { counter-reset: h2; }
+.post-body h2 { counter-reset: h3; }
+.post-body h2::before {
+  counter-increment: h2;
+  content: counter(h2) ". ";
+  color: #6b7681;
+}
+.post-body h3::before {
+  counter-increment: h3;
+  content: counter(h2) "." counter(h3) " ";
+  color: #6b7681;
+}
+
 /* Clickable anchor that appears on heading hover. */
 .heading-anchor {
   margin-left: 8px;
@@ -511,6 +526,33 @@ html { scroll-behavior: smooth; }
 /* The TOC stays inline at the top of the article on all widths. A floating
    sidebar was removed: the 1000px container leaves no reliable room for it and
    it overlapped the text on some widths/scroll positions. */
+
+/* Post layout: content + TOC. On narrow screens it is a single column with the
+   TOC on top. On wide screens it becomes two columns (content + sticky TOC),
+   and the page container widens to make real room for the side column so the
+   TOC never overlaps the text. */
+.post-grid { display: block; }
+
+@media (min-width: 1280px) {
+  /* Widen the container only on post pages (which contain .post-grid). */
+  .container:has(.post-grid) { max-width: 1340px; }
+
+  .post-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 260px;
+    column-gap: 40px;
+    align-items: start;
+  }
+  .post-grid .post-body { grid-column: 1; min-width: 0; }
+  .post-grid .toc {
+    grid-column: 2;
+    position: sticky;
+    top: 16px;
+    margin: 0;
+    max-height: calc(100vh - 40px);
+    overflow-y: auto;
+  }
+}
 
 /* Reinforced visible focus for all interactive elements (a11y). */
 .copy-btn:focus-visible,

--- a/assets/anchors.js
+++ b/assets/anchors.js
@@ -27,7 +27,7 @@
       a.href = "#" + h.id;
       a.className = "heading-anchor";
       a.textContent = "#";
-      a.setAttribute("aria-hidden", "true");
+      a.setAttribute("aria-label", "Link para esta seção");
       h.appendChild(a);
 
       // TOC entry (h3 indented under h2).


### PR DESCRIPTION
- TOC: 2-column grid (content + sticky side TOC) on wide screens (>=1280px), with the container widened on post pages so the TOC never overlaps the text; single column (TOC on top) on narrow screens. Keeps the reading progress bar.
- Section numbering: back to automatic CSS counters (no manual numbers needed in posts).
- A11y (from Lighthouse): add html lang=pt-BR, <main> landmark, allow pinch-zoom (drop maximum-scale), fix focusable anchor aria. Baseline was a11y 82 / perf 86.