### PR TITLE
Scroll-spy TOC, favicon, typography polish

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,6 @@
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
   <meta
     name="viewport"
     content="width=device-width, initial-scale=1.0"

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -563,3 +563,30 @@ button:focus-visible {
   outline-offset: 2px;
   border-radius: 2px;
 }
+
+/* Deep-link target spacing: headings (and #top) get breathing room when an
+   anchor scrolls them to the top of the viewport, instead of touching the edge. */
+.post-body h2,
+.post-body h3,
+#top {
+  scroll-margin-top: 24px;
+}
+
+/* Scroll-spy: highlight the TOC entry for the section currently in view. */
+.toc-list a.toc-active {
+  color: $conifer;
+  font-weight: bold;
+}
+
+/* Finer reading typography. Hyphenation only on narrow screens, where long
+   words would otherwise create ragged gaps; code is never hyphenated. */
+body {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+@media (max-width: 600px) {
+  .post-body p,
+  .post-body li {
+    hyphens: auto;
+  }
+}

--- a/assets/anchors.js
+++ b/assets/anchors.js
@@ -1,13 +1,10 @@
-// Builds the table of contents from the post headings and adds a clickable
-// anchor to each heading for deep linking. Same-origin script, allowed by the
-// existing CSP (script-src 'self').
+// Builds the TOC from post headings, numbers it to match the CSS counter,
+// adds heading anchors, scroll-spy (highlight current section) and a reading
+// progress bar. Same-origin script, allowed by CSP (script-src 'self').
 (function () {
   function slugify(text) {
-    return text
-      .toLowerCase()
-      .trim()
-      .replace(/[^\w\s-]/g, "")
-      .replace(/\s+/g, "-");
+    return text.toLowerCase().trim()
+      .replace(/[^\w\s-]/g, "").replace(/\s+/g, "-");
   }
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -17,12 +14,14 @@
 
     var list = toc.querySelector(".toc-list");
     var headings = body.querySelectorAll("h2, h3");
-    if (headings.length < 3) return; // not worth a TOC for short posts
+    if (headings.length < 3) return;
+
+    var h2 = 0, h3 = 0;
+    var entries = []; // {id, link} for scroll-spy
 
     headings.forEach(function (h) {
       if (!h.id) h.id = slugify(h.textContent);
 
-      // Clickable anchor on the heading itself.
       var a = document.createElement("a");
       a.href = "#" + h.id;
       a.className = "heading-anchor";
@@ -30,29 +29,45 @@
       a.setAttribute("aria-label", "Link para esta seção");
       h.appendChild(a);
 
-      // TOC entry (h3 indented under h2).
+      var num;
+      if (h.tagName === "H2") { h2++; h3 = 0; num = h2 + ". "; }
+      else { h3++; num = h2 + "." + h3 + " "; }
+
       var li = document.createElement("li");
       li.className = "toc-" + h.tagName.toLowerCase();
       var link = document.createElement("a");
       link.href = "#" + h.id;
-      link.textContent = h.textContent.replace(/#$/, "");
+      link.textContent = num + h.textContent.replace(/#$/, "");
       li.appendChild(link);
       list.appendChild(li);
+      entries.push({ el: h, link: link });
     });
 
     toc.hidden = false;
+
+    // Scroll-spy: mark the heading nearest the top as active.
+    function spy() {
+      var pos = window.scrollY + 100;
+      var active = entries[0];
+      for (var i = 0; i < entries.length; i++) {
+        if (entries[i].el.offsetTop <= pos) active = entries[i];
+      }
+      entries.forEach(function (e) {
+        e.link.classList.toggle("toc-active", e === active);
+      });
+    }
+    window.addEventListener("scroll", spy, { passive: true });
+    spy();
   });
 
-  // Reading progress bar: width tracks scroll position through the article.
+  // Reading progress bar.
   document.addEventListener("DOMContentLoaded", function () {
     var bar = document.getElementById("reading-progress");
     var body = document.querySelector(".post-body");
     if (!bar || !body) return;
-
     function update() {
       var max = document.documentElement.scrollHeight - window.innerHeight;
-      var pct = max > 0 ? (window.scrollY / max) * 100 : 0;
-      bar.style.width = pct + "%";
+      bar.style.width = (max > 0 ? (window.scrollY / max) * 100 : 0) + "%";
     }
     window.addEventListener("scroll", update, { passive: true });
     window.addEventListener("resize", update);

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#12161c"/>
+  <text x="5" y="22" font-family="Monaco, Menlo, monospace" font-size="15" font-weight="bold" fill="#b5e853">&gt;_</text>
+</svg>


### PR DESCRIPTION
- TOC: numbered to match the body section numbers; scroll-spy highlights the current section as you scroll.
- scroll-margin-top on headings/#top so anchor jumps do not stick to the viewport edge.
- Finer typography (optimizeLegibility; hyphenation on <=600px only; code never hyphenated).
- Add SVG favicon (terminal >_ in the theme colors) to fix the favicon.ico 404.
- Reading width intentionally NOT changed (keeps code blocks full-width).