### PR TITLE
Fix: TOC at top on narrow screens (<1280px)

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -533,6 +533,14 @@ html { scroll-behavior: smooth; }
    TOC never overlaps the text. */
 .post-grid { display: block; }
 
+/* Narrow screens (<1280px): flex column so the TOC can be ordered ABOVE the
+   content. In plain block flow `order` has no effect and the TOC (last child)
+   would fall to the bottom of the article. */
+@media (max-width: 1279px) {
+  .post-grid { display: flex; flex-direction: column; }
+  .post-grid .toc { order: -1; }
+}
+
 @media (min-width: 1280px) {
   /* Widen the container only on post pages (which contain .post-grid). */
   .container:has(.post-grid) { max-width: 1340px; }


### PR DESCRIPTION
Below 1280px the layout was plain block flow, so the .toc (last child of .post-grid) fell to the bottom of the article. Make .post-grid a flex column with order:-1 on the TOC in that range, so it appears above the content as intended. Sticky sidebar at >=1280px unchanged.