### PR TITLE
Obfuscate easter-egg flag + trim JS comments

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--
-  Curioso o suficiente para ler o source? Bom instinto.
-  FLAG{v13w_s0urc3_a1nda_func10na_em_2026}
-  Manda um alô (ou um PR) se achou: linkedin.com/in/rozapelini
--->
 <html lang="pt-BR">
 {% include head.html %}
 

--- a/assets/anchors.js
+++ b/assets/anchors.js
@@ -1,6 +1,4 @@
-// Builds the TOC from post headings, numbers it to match the CSS counter,
-// adds heading anchors, scroll-spy (highlight current section) and a reading
-// progress bar. Same-origin script, allowed by CSP (script-src 'self').
+// TOC (numbered) + heading anchors + scroll-spy + reading progress bar.
 (function () {
   function slugify(text) {
     return text.toLowerCase().trim()
@@ -17,7 +15,7 @@
     if (headings.length < 3) return;
 
     var h2 = 0, h3 = 0;
-    var entries = []; // {id, link} for scroll-spy
+    var entries = [];
 
     headings.forEach(function (h) {
       if (!h.id) h.id = slugify(h.textContent);
@@ -45,7 +43,6 @@
 
     toc.hidden = false;
 
-    // Scroll-spy: mark the heading nearest the top as active.
     function spy() {
       var pos = window.scrollY + 100;
       var active = entries[0];
@@ -60,7 +57,6 @@
     spy();
   });
 
-  // Reading progress bar.
   document.addEventListener("DOMContentLoaded", function () {
     var bar = document.getElementById("reading-progress");
     var body = document.querySelector(".post-body");

--- a/assets/copy-code.js
+++ b/assets/copy-code.js
@@ -1,6 +1,4 @@
-// Builds a real macOS-style title bar (traffic lights + language label + copy
-// button) at the top of every code block. Same-origin script, allowed by the
-// existing CSP (script-src 'self'); no inline code.
+// Renders a macOS-style title bar (dots, language, copy) on each code block.
 (function () {
   function langOf(block) {
     var m = (block.className || "").match(/language-(\w+)/);

--- a/assets/easteregg.js
+++ b/assets/easteregg.js
@@ -15,8 +15,7 @@
   console.log(
     "%cVocê abriu o console num blog de AppSec. Faz sentido.\n" +
     "Mas se alguém te mandou COLAR algo aqui prometendo hackear o Insta de alguém,\n" +
-    "parabéns: o exploit é em VOCÊ. Isso se chama self-XSS. Não cole nada.\n\n" +
-    "Curioso? Tem um segredo neste arquivo. unlock() revela.",
+    "parabéns: o exploit é em VOCÊ. Isso se chama self-XSS. Não cole nada.",
     s2
   );
 

--- a/assets/easteregg.js
+++ b/assets/easteregg.js
@@ -1,8 +1,14 @@
-// Easter eggs. Same-origin script, allowed by CSP (script-src 'self').
-// 1) Konami code -> a few seconds of Matrix rain.
-// 2) An ironic console warning aimed at an AppSec audience.
+// nem tudo que parece ruído é ruído. boa sorte. 0x5c
 (function () {
-  /* ---- Console trap (ironic, on brand for an AppSec blog) ---- */
+  var _0x3f = [0x37,0x76,0x92,0x8c,0x86,0x37,0x4f,0x79,0x89,0x6d,0x66,0x2c,0x43,0x8b,0x7e,0x89,0xb2,0xbf,0xa3,0xa0,0xa2,0xfd,0xc3,0xa3,0x05,0xeb,0xd2,0xd1,0xa4,0xdb,0xcd,0xeb,0xc5,0xbd,0x0e,0x07,0x39,0x2d,0x30,0x1a];
+  function _0xd(_0xa, _0xk) {
+    var _0xr = _0xa.slice().reverse(), _0xs = "";
+    for (var _0xi = 0; _0xi < _0xr.length; _0xi++)
+      _0xs += String.fromCharCode(((_0xr[_0xi] - _0xi) & 0xff) ^ ((_0xk + _0xi * 7) & 0xff));
+    return _0xs;
+  }
+  window.unlock = function () { return _0xd(_0x3f, 0x5c); };
+
   var s1 = "color:#b5e853;font-size:20px;font-family:monospace";
   var s2 = "color:#9aa4b0;font-size:13px;font-family:monospace";
   console.log("%c$ whoami", s1);
@@ -10,14 +16,11 @@
     "%cVocê abriu o console num blog de AppSec. Faz sentido.\n" +
     "Mas se alguém te mandou COLAR algo aqui prometendo hackear o Insta de alguém,\n" +
     "parabéns: o exploit é em VOCÊ. Isso se chama self-XSS. Não cole nada.\n\n" +
-    "Agora, se você veio fuçar de curioso: respeito. Tem uma flag escondida\n" +
-    "em algum lugar deste site. Boa sorte. (dica: nem todo segredo está no JS)",
+    "Curioso? Tem um segredo neste arquivo. unlock() revela.",
     s2
   );
 
-  /* ---- Konami code -> Matrix rain ---- */
-  var seq = [38, 38, 40, 40, 37, 39, 37, 39, 66, 65];
-  var pos = 0;
+  var seq = [38, 38, 40, 40, 37, 39, 37, 39, 66, 65], pos = 0;
   document.addEventListener("keydown", function (e) {
     pos = e.keyCode === seq[pos] ? pos + 1 : 0;
     if (pos === seq.length) { pos = 0; matrix(); }
@@ -27,18 +30,12 @@
     if (document.getElementById("matrix-egg")) return;
     var c = document.createElement("canvas");
     c.id = "matrix-egg";
-    c.style.cssText =
-      "position:fixed;inset:0;z-index:9999;background:#000;pointer-events:none";
+    c.style.cssText = "position:fixed;inset:0;z-index:9999;background:#000;pointer-events:none";
     document.body.appendChild(c);
     var ctx = c.getContext("2d");
-    function size() { c.width = innerWidth; c.height = innerHeight; }
-    size();
-
-    var chars = "01アイウエカ$>_#@&%".split("");
-    var fs = 16;
-    var cols = Math.floor(c.width / fs);
-    var drops = new Array(cols).fill(1);
-
+    c.width = innerWidth; c.height = innerHeight;
+    var chars = "01アイウエカ$>_#@&%".split(""), fs = 16;
+    var drops = new Array(Math.floor(c.width / fs)).fill(1);
     var timer = setInterval(function () {
       ctx.fillStyle = "rgba(0,0,0,0.08)";
       ctx.fillRect(0, 0, c.width, c.height);
@@ -50,7 +47,6 @@
         drops[i]++;
       }
     }, 50);
-
     setTimeout(function () { clearInterval(timer); c.remove(); }, 5000);
   }
 })();


### PR DESCRIPTION
- Remove the plaintext FLAG comment from the HTML source.
- Hide the flag obfuscated in easteregg.js (shuffled/XOR-rolled byte array, reconstructed at runtime via unlock()); only a cryptic one-line hint remains.
- Trim non-essential comments from copy-code.js and anchors.js.
- Drop the 'segredo nem todo no JS' line from the console message.