### PR TITLE
Theme switcher: 6 terminal palettes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,6 @@
 <head>
   <meta charset="UTF-8" />
+  <script>(function(){var a=["default","solarized-dark","solarized-light","black-on-white","white-on-black","green-on-black"];try{var v=localStorage.getItem("theme");document.documentElement.setAttribute("data-theme",a.indexOf(v)>-1?v:"default")}catch(e){}})();</script>
   <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
   <meta
     name="viewport"
@@ -7,7 +8,7 @@
   />
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'none'; script-src 'self' 'sha256-mOt5CQEidsRudZgzHoj8tnDYBi4K6FxrEQJWv1mhzX0='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'self'; manifest-src 'self'"
+    content="default-src 'none'; script-src 'self' 'sha256-mOt5CQEidsRudZgzHoj8tnDYBi4K6FxrEQJWv1mhzX0=' 'sha256-Je6k0hYm/sk+Y5Dw49VVmfSzyc0wvDcGF1CH8N9yDJs='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'self'; manifest-src 'self'"
   />
 
   <title>
@@ -38,5 +39,6 @@
   <script src="/assets/copy-code.js?v={{ site.time | date: '%s' }}" defer></script>
   <script src="/assets/anchors.js?v={{ site.time | date: '%s' }}" defer></script>
   <script src="/assets/easteregg.js?v={{ site.time | date: '%s' }}" defer></script>
+  <script src="/assets/theme.js?v={{ site.time | date: '%s' }}" defer></script>
   {% seo %}
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,5 @@
 <header>
+  <span id="theme-switcher"></span>
   <div>
     <a href="{{ "/" | prepend: site.baseurl | replace: '//', '/' }}">
     {% assign owner_first_name = site.owner | split: " " %}

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -1,0 +1,92 @@
+/* Theme variables. The JS only sets data-theme on <html> from a fixed allowlist,
+   so no untrusted value ever reaches the DOM/CSS (XSS-safe). */
+:root,
+:root[data-theme="default"] {
+  --bg: #12161c;
+  --fg: #c9d1d9;
+  --accent: #b5e853;       /* primary green (titles, prompt, tags) */
+  --accent-soft: #a8c977;  /* desaturated green (content headings) */
+  --muted: #9a9a9a;
+  --link: #7fd4ff;
+  --link-hover: #b5e8ff;
+  --code-bg: rgba(0, 0, 0, 0.9);
+  --code-fg: #c9d1d9;
+  --inline-code: #aa759f;
+  --border: rgba(255, 255, 255, 0.15);
+  --bar-bg: rgba(255, 255, 255, 0.04);
+}
+
+:root[data-theme="solarized-dark"] {
+  --bg: #002b36;
+  --fg: #839496;
+  --accent: #268bd2;
+  --accent-soft: #2aa198;
+  --muted: #586e75;
+  --link: #268bd2;
+  --link-hover: #6c9ec9;
+  --code-bg: #073642;
+  --code-fg: #93a1a1;
+  --inline-code: #d33682;
+  --border: rgba(147, 161, 161, 0.25);
+  --bar-bg: rgba(147, 161, 161, 0.08);
+}
+
+:root[data-theme="solarized-light"] {
+  --bg: #fdf6e3;
+  --fg: #657b83;
+  --accent: #268bd2;
+  --accent-soft: #2aa198;
+  --muted: #93a1a1;
+  --link: #268bd2;
+  --link-hover: #1a6091;
+  --code-bg: #eee8d5;
+  --code-fg: #586e75;
+  --inline-code: #d33682;
+  --border: rgba(101, 123, 131, 0.25);
+  --bar-bg: rgba(101, 123, 131, 0.08);
+}
+
+:root[data-theme="black-on-white"] {
+  --bg: #ffffff;
+  --fg: #000000;
+  --accent: #006400;
+  --accent-soft: #006400;
+  --muted: #555555;
+  --link: #0000ee;
+  --link-hover: #551a8b;
+  --code-bg: #f4f4f4;
+  --code-fg: #1a1a1a;
+  --inline-code: #b00060;
+  --border: rgba(0, 0, 0, 0.2);
+  --bar-bg: rgba(0, 0, 0, 0.05);
+}
+
+:root[data-theme="white-on-black"] {
+  --bg: #000000;
+  --fg: #ffffff;
+  --accent: #ffffff;
+  --accent-soft: #cccccc;
+  --muted: #999999;
+  --link: #8ab4f8;
+  --link-hover: #c6dafc;
+  --code-bg: #0d0d0d;
+  --code-fg: #ffffff;
+  --inline-code: #ff8ad8;
+  --border: rgba(255, 255, 255, 0.25);
+  --bar-bg: rgba(255, 255, 255, 0.06);
+}
+
+:root[data-theme="green-on-black"] {
+  --bg: #000000;
+  --fg: #33ff33;
+  --accent: #33ff33;
+  --accent-soft: #2ad42a;
+  --muted: #1f991f;
+  --link: #33ff33;
+  --link-hover: #99ff99;
+  --code-bg: #001a00;
+  --code-fg: #33ff33;
+  --inline-code: #99ff99;
+  --border: rgba(51, 255, 51, 0.3);
+  --bar-bg: rgba(51, 255, 51, 0.06);
+}

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -4,18 +4,14 @@
 
 @import "rouge-base16-dark";
 @import "default_colors";
+@import "themes";
 
-$body-background: $cod-grey !default;
-$body-foreground: $gallery !default;
-$header: $conifer !default;
-$blockquote-color: $silver-chalice !default;
-$blockquote-border: $dove-grey !default;
 
 body {
   margin: 0;
   padding: 0;
-  background: $body-background url("../assets/bkg.png") 0 0;
-  color: $body-foreground;
+  background: var(--bg);
+  color: var(--fg);
   font-size: 16px;
   line-height: 1.7;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
@@ -57,7 +53,7 @@ li {
 
 header {
   background: rgba(0, 0, 0, 0.1);
-  border-bottom: 1px dashed $conifer; //header;
+  border-bottom: 1px dashed var(--accent); //header;
   padding: 20px;
   margin: 0 0 40px 0;
 }
@@ -77,10 +73,10 @@ header h1 {
   text-align: center;
   font-weight: bold;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  color: $conifer;//$header;
+  color: var(--accent);//var(--accent);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1),
-               0 0 5px rgba(181, 232, 83, 0.1),
-               0 0 10px rgba(181, 232, 83, 0.1);
+               0 0 5px var(--bar-bg),
+               0 0 10px var(--bar-bg);
   letter-spacing: -1px;
   -webkit-font-smoothing: antialiased;
 }
@@ -88,7 +84,7 @@ header h1 {
 header h2 {
   font-size: 18px;
   font-weight: 300;
-  color: #9a9a9a;
+  color: var(--muted);
 }
 
 /* Main Content
@@ -105,7 +101,7 @@ section img {
 h1, h2, h3, h4, h5, h6 {
   font-weight: normal;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  color: $header;
+  color: var(--accent);
   letter-spacing: -0.03em;
 }
 
@@ -115,12 +111,12 @@ h1, h2, h3, h4, h5, h6 {
 
 #main_content h2 {
   font-size: 26px;
-  color: #a8c977;
+  color: var(--accent-soft);
 }
 
 #main_content h3 {
   font-size: 20px;
-  color: #a8c977;
+  color: var(--accent-soft);
 }
 
 #main_content h4 {
@@ -136,7 +132,7 @@ h1, h2, h3, h4, h5, h6 {
 #main_content h6 {
   font-size: 12px;
   text-transform: uppercase;
-  color: #9a9a9a;
+  color: var(--muted);
   margin: 0 0 5px 0;
 }
 
@@ -151,7 +147,7 @@ ul li {
 
 ul li::before {
   content: ">> " / "";
-  color: #a8c977;
+  color: var(--accent-soft);
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
 }
 
@@ -161,21 +157,21 @@ ul li time {
   display: inline;
   margin: 0;
   font-size: inherit;
-  color: #9a9a9a;
+  color: var(--muted);
 }
 
 blockquote {
-  color: $blockquote-color;
+  color: var(--muted);
   padding-left: 10px;
-  border-left: 1px dotted $blockquote-border;
+  border-left: 1px dotted var(--border);
 }
 
 pre {
-  background: rgba(0, 0, 0, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
   padding: 10px;
   font-size: 16px;
-  color: #c9d1d9;
+  color: var(--code-fg);
   border-radius: 2px;
   text-wrap: normal;
   overflow: auto;
@@ -186,8 +182,8 @@ pre {
    is injected by /assets/copy-code.js as the first child of the wrapper. */
 div.highlighter-rouge,
 figure.highlight {
-  background: rgba(0, 0, 0, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
   border-radius: 8px;
   margin: 0 0 20px 0;
   overflow: hidden;
@@ -200,8 +196,8 @@ figure.highlight {
   gap: 10px;
   height: 34px;
   padding: 0 12px;
-  background: rgba(255, 255, 255, 0.04);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bar-bg);
+  border-bottom: 1px solid var(--border);
 }
 
 /* Three traffic-light buttons drawn with a single element + box-shadow. */
@@ -218,14 +214,14 @@ figure.highlight {
   margin-left: auto;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   font-size: 12px;
-  color: #9aa4b0;
+  color: var(--muted);
   letter-spacing: 0.5px;
 }
 
 .copy-btn {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: #c9d1d9;
+  background: var(--bar-bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   font-size: 11px;
   padding: 2px 8px;
@@ -233,7 +229,7 @@ figure.highlight {
   cursor: pointer;
 }
 .copy-btn:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border);
 }
 
 /* The inner highlight div and pre sit flush inside the window. */
@@ -247,11 +243,11 @@ figure.highlight pre {
 }
 
 code.highlighter-rouge {
-  background: rgba(0,0,0,0.9);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
   padding: 0px 3px;
   margin: 0px -3px;
-  color: #aa759f;
+  color: var(--inline-code);
   border-radius: 2px;
 }
 
@@ -262,7 +258,7 @@ table {
 
 th {
   text-align: left;
-  border-bottom: 1px dashed #b5e853;
+  border-bottom: 1px dashed var(--accent);
   padding: 5px 10px;
 }
 
@@ -291,8 +287,8 @@ td {
 hr {
   height: 0;
   border: 0;
-  border-bottom: 1px dashed #b5e853;
-  color: #b5e853;
+  border-bottom: 1px dashed var(--accent);
+  color: var(--accent);
 }
 
 /* Buttons
@@ -337,16 +333,16 @@ hr {
 */
 
 a {
-  color: #7fd4ff;
+  color: var(--link);
   text-shadow: 0 0 5px rgba(104, 182, 255, 0.3);
 }
 
 a:hover {
-  color: #b5e8ff;
+  color: var(--link-hover);
 }
 
 a:focus-visible {
-  outline: 2px solid $conifer;
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -354,7 +350,7 @@ a:focus-visible {
 /* Post date styling */
 time, .post-date {
   display: block;
-  color: #9a9a9a;
+  color: var(--muted);
   font-size: 14px;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   margin: -10px 0 20px 0;
@@ -367,9 +363,9 @@ time, .post-date {
 
 .tag {
   display: inline-block;
-  background: rgba(181, 232, 83, 0.1);
-  border: 1px solid rgba(181, 232, 83, 0.3);
-  color: $conifer;
+  background: var(--bar-bg);
+  border: 1px solid var(--border);
+  color: var(--accent);
   font-size: 12px;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   padding: 2px 8px;
@@ -379,8 +375,8 @@ time, .post-date {
 }
 
 .tag:hover {
-  background: rgba(181, 232, 83, 0.2);
-  border-color: rgba(181, 232, 83, 0.6);
+  background: var(--bar-bg);
+  border-color: var(--accent);
   text-shadow: none;
 }
 
@@ -428,7 +424,7 @@ html { scroll-behavior: smooth; }
 /* Reading time next to the date. */
 .reading-time {
   display: inline-block;
-  color: #9a9a9a;
+  color: var(--muted);
   font-size: 14px;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   margin: -10px 0 20px 0;
@@ -436,16 +432,16 @@ html { scroll-behavior: smooth; }
 
 /* Table of contents. */
 .toc {
-  border: 1px solid rgba(181, 232, 83, 0.25);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 12px 18px;
   margin: 0 0 30px 0;
-  background: rgba(181, 232, 83, 0.04);
+  background: var(--bar-bg);
 }
 .toc-title {
   margin: 0 0 8px 0;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  color: $conifer;
+  color: var(--accent);
   font-size: 14px;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -463,12 +459,12 @@ html { scroll-behavior: smooth; }
 .post-body h2::before {
   counter-increment: h2;
   content: counter(h2) ". ";
-  color: #6b7681;
+  color: var(--muted);
 }
 .post-body h3::before {
   counter-increment: h3;
   content: counter(h2) "." counter(h3) " ";
-  color: #6b7681;
+  color: var(--muted);
 }
 
 /* Clickable anchor that appears on heading hover. */
@@ -484,22 +480,22 @@ html { scroll-behavior: smooth; }
 
 /* How-to-cite block. */
 .cite-block {
-  border-top: 1px dashed rgba(181, 232, 83, 0.4);
+  border-top: 1px dashed var(--border);
   margin: 40px 0 0 0;
   padding-top: 20px;
 }
 .cite-title {
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  color: $conifer;
+  color: var(--accent);
   font-size: 14px;
   text-transform: uppercase;
   letter-spacing: 1px;
   margin: 0 0 8px 0;
 }
-.cite-text { color: #9a9a9a; font-size: 14px; }
+.cite-text { color: var(--muted); font-size: 14px; }
 .cite-bibtex {
   font-size: 13px;
-  color: #c9d1d9;
+  color: var(--code-fg);
 }
 
 /* Back to top. */
@@ -518,7 +514,7 @@ html { scroll-behavior: smooth; }
   left: 0;
   height: 3px;
   width: 0;
-  background: $conifer;
+  background: var(--accent);
   z-index: 50;
 }
 
@@ -567,7 +563,7 @@ html { scroll-behavior: smooth; }
 .tag:focus-visible,
 .page-item:focus-visible,
 button:focus-visible {
-  outline: 2px solid $conifer;
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -582,7 +578,7 @@ button:focus-visible {
 
 /* Scroll-spy: highlight the TOC entry for the section currently in view. */
 .toc-list a.toc-active {
-  color: $conifer;
+  color: var(--accent);
   font-weight: bold;
 }
 
@@ -605,4 +601,29 @@ body {
   border-color: rgba(172, 65, 66, 0.4);
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+/* Theme switcher (top-right of the header). */
+header { position: relative; }
+#theme-switcher {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+}
+.theme-select {
+  background: var(--bar-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
+  font-size: 12px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+.theme-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+@media (max-width: 600px) {
+  #theme-switcher { position: static; text-align: center; margin: 10px 0 0; }
 }

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,0 +1,45 @@
+// Theme switcher. The chosen value is validated against a fixed allowlist before
+// use, so a tampered localStorage value can never reach the DOM/CSS (XSS-safe).
+(function () {
+  var THEMES = [
+    ["default", "default"],
+    ["solarized-dark", "solarized dark"],
+    ["solarized-light", "solarized light"],
+    ["black-on-white", "black on white"],
+    ["white-on-black", "white on black"],
+    ["green-on-black", "green on black"]
+  ];
+  var KEY = "theme";
+  var ALLOWED = THEMES.map(function (t) { return t[0]; });
+
+  function safeGet() {
+    try { var v = localStorage.getItem(KEY); return ALLOWED.indexOf(v) > -1 ? v : "default"; }
+    catch (e) { return "default"; }
+  }
+  function apply(v) {
+    if (ALLOWED.indexOf(v) === -1) v = "default";
+    document.documentElement.setAttribute("data-theme", v);
+  }
+
+  apply(safeGet());
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var mount = document.getElementById("theme-switcher");
+    if (!mount) return;
+    var sel = document.createElement("select");
+    sel.setAttribute("aria-label", "Tema do site");
+    sel.className = "theme-select";
+    THEMES.forEach(function (t) {
+      var o = document.createElement("option");
+      o.value = t[0];
+      o.textContent = t[1];
+      sel.appendChild(o);
+    });
+    sel.value = safeGet();
+    sel.addEventListener("change", function () {
+      apply(sel.value);
+      try { localStorage.setItem(KEY, sel.value); } catch (e) {}
+    });
+    mount.appendChild(sel);
+  });
+})();


### PR DESCRIPTION
- 6 themes via CSS custom properties + :root[data-theme]: default (current), solarized dark/light, black-on-white, white-on-black, green-on-black.
- theme.js: validates the stored value against a fixed allowlist before applying (no untrusted value reaches DOM/CSS); persists in localStorage; builds a select in the header (top-right, responsive).
- Anti-FOUC inline script in <head> applies the saved theme before paint; its hash is added to the CSP (meta + Cloudflare header).
- All hardcoded colors refactored to theme variables (body, headings, code terminal, tags, TOC, links, tables, blockquote).