### PR TITLE
Theme select: place in nav + fix dropdown colors

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,4 @@
 <header>
-  <span id="theme-switcher"></span>
   <div>
     <a href="{{ "/" | prepend: site.baseurl | replace: '//', '/' }}">
     {% assign owner_first_name = site.owner | split: " " %}

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -2,3 +2,4 @@
 <a href="{{ "/tags" | prepend: site.baseurl | replace: '//', '/' }}"><h2 class="header-link">Tags</h2></a>
 <a href="{{ "/about" | prepend: site.baseurl | replace: '//', '/' }}"><h2 class="header-link">About</h2></a>
 <a href="{{ "/atom.xml" | prepend: site.baseurl | replace: '//', '/' }}"><h2 class="header-link">RSS</h2></a>
+<span id="theme-switcher" class="header-link"></span>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -604,26 +604,25 @@ body {
 }
 
 /* Theme switcher (top-right of the header). */
-header { position: relative; }
 #theme-switcher {
-  position: absolute;
-  top: 12px;
-  right: 16px;
+  display: inline-block;
+  vertical-align: middle;
 }
 .theme-select {
-  background: var(--bar-bg);
+  background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
   border-radius: 4px;
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  font-size: 12px;
-  padding: 3px 6px;
+  font-size: 14px;
+  padding: 2px 6px;
   cursor: pointer;
+}
+.theme-select option {
+  background: var(--bg);
+  color: var(--fg);
 }
 .theme-select:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-}
-@media (max-width: 600px) {
-  #theme-switcher { position: static; text-align: center; margin: 10px 0 0; }
 }


### PR DESCRIPTION
- Move the theme <select> into the header nav line (after RSS) so it is anchored, not floating in the corner.
- Force background/color on the select and its <option> elements using theme variables, fixing the odd dropdown appearance on some themes.