### PR TITLE
Enable Dependabot (GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Weekly Dependabot updates for GitHub Actions dependencies, so actions like actions/checkout stay current (the kind of thing behind the earlier Node 20 deprecation warning).